### PR TITLE
Add -F --feature argument that is passed along to cargo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,18 @@ There are cli options that you can use to modify how the examples are ran:
 
 ```
 Cargo subcommand to run all examples for any locally cloned crate
-
 USAGE:
-    cargo examples [OPTIONS]
-
+    cargo examples [OPTIONS] [-- <CARGO_ARGS>...]
+ARGUMENTS:
+    [CARGO_ARGS]...  Pass these arguments along to cargo when running
 OPTIONS:
-    -f, --from <EXAMPLE>          Run example starting with <EXAMPLE>
-    -h, --help                    Print help information
-    -l, --list                    List *all* examples and print them out before running any
-        --manifest-path <FILE>    Path to Cargo.toml
-    -n, --no-run                  Do not run any examples, useful when combined with `--list`, or
-                                  `--from` + `--print`
-    -p, --print                   Print example name before running
-    -V, --version                 Print version information
+        --manifest-path <FILE>  Path to Cargo.toml
+    -l, --list                  List *all* examples and print them out before running any
+    -p, --print                 Print example name before running
+    -f, --from <EXAMPLE>        Run example starting with <EXAMPLE>
+    -n, --no-run                Do not run any examples, useful when combined with `--list`, or `--from` + `--print`
+    -s, --skip <EXAMPLE>        Skip <EXAMPLE> when running. (--skip=example1,example2)
+    -F, --features <FEATURES>   Run examples with <FEATURES> enabled. (--features=feature1,feature2)
+    -h, --help                  Print help
+    -V, --version               Print version
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,6 +52,16 @@ struct Examples {
     )]
     skip: Vec<OsString>,
 
+    /// Run examples with <FEATURES> enabled. (--features=feature1,feature2)
+    #[clap(
+        short = 'F',
+        long,
+        value_parser,
+        use_value_delimiter = true,
+        value_name = "FEATURES"
+    )]
+    features: Vec<String>,
+
     /// Pass these arguments along to cargo when running
     #[clap(raw = true)]
     cargo_args: Option<String>,
@@ -160,6 +170,15 @@ fn main() -> anyhow::Result<()> {
     // if `from` is not specified run all examples
     let mut run_examples = cli.from.is_none();
 
+    // if 'features' is specified pass them allong to cargo
+    let features = if cli.features.is_empty() {
+        String::from("")
+    } else {
+        let mut f = "--features=".to_owned();
+        f.push_str(cli.features.join(",").as_str());
+        f
+    };
+
     for example in &examples {
         if let Some(ref from) = cli.from {
             // execute only example starting with `from`, if `from` is specified
@@ -192,18 +211,18 @@ fn main() -> anyhow::Result<()> {
                 let name = example.name().unwrap();
                 cmd!(
                     sh,
-                    "cargo run --manifest-path {manifest_path} --example {name}"
+                    "cargo run --manifest-path {manifest_path} --example {name} {features}"
                 )
             }
             Example::MultiFile(_) => {
                 let name = example.name().unwrap();
                 cmd!(
                     sh,
-                    "cargo run --manifest-path {manifest_path} --example {name}"
+                    "cargo run --manifest-path {manifest_path} --example {name} {features}"
                 )
             }
             Example::SubProject(manifest_path) => {
-                cmd!(sh, "cargo run --manifest-path {manifest_path}")
+                cmd!(sh, "cargo run --manifest-path {manifest_path} {features}")
             }
         };
 


### PR DESCRIPTION
This makes passing allong features nicer, because features are a common parameter.

Instead of using `cargo examples -- --features=feature1` we can now call `cargo examples --features=feature1`.